### PR TITLE
Configure vercel.json for monorepo deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,30 @@
+{
+  "builds": [
+    {
+      "src": "web/package.json",
+      "use": "@vercel/static-build",
+      "config": {
+        "installCommand": "npm install --prefix web",
+        "buildCommand": "npm run build --prefix web",
+        "outputDirectory": "web/dist"
+      }
+    },
+    {
+      "src": "api/server.js",
+      "use": "@vercel/node",
+      "config": {
+        "installCommand": "npm install --prefix api"
+      }
+    }
+  ],
+  "rewrites": [
+    {
+      "source": "/api/(.*)",
+      "destination": "/api/server.js"
+    },
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
Updates the vercel.json to correctly build and deploy both the frontend and backend services.

- Defines separate build configurations for the `web` (frontend) and `api` (backend) directories.
- Sets up rewrite rules to direct `/api` traffic to the backend and all other requests to the frontend.